### PR TITLE
Version 0.6.1 reduces output package size significantly from 13mb to 1.7mb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.boundary</groupId>
   <artifactId>java-plugin-sdk</artifactId>
-  <version>0.6.0</version>
+  <version>0.6.1</version>
   <name>Boundary Java Plugin SDK</name>
   <properties>
     <!-- Plugin Versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,6 @@
       <artifactId>guava</artifactId>
       <version>${guava-version}</version>
     </dependency>
-   <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
-      <version>${javaee-api-version}</version>
-    </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit-version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,22 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
         <version>${maven-gpg-plugin-version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,14 +23,12 @@
     <cobertura-maven-plugin-version>2.6</cobertura-maven-plugin-version>
     <core-version>1.0-b02</core-version>
     <findbugs-maven-plugin-version>3.0.0</findbugs-maven-plugin-version>
-    <guava-version>18.0</guava-version>
     <slf4j-api-version>1.7.7</slf4j-api-version>
     <slf4j-log4j12-version>1.7.7</slf4j-log4j12-version>
     <log4j-version>1.2.17</log4j-version>
     <jackson-version>2.4.3</jackson-version>
     <javaee-api-version>6.0</javaee-api-version>
     <junit-version>4.11</junit-version>
-    <org-hibernate-version>4.3.7.final</org-hibernate-version>
   </properties>
   <dependencies>
      <dependency>
@@ -43,12 +41,7 @@
       <artifactId>core</artifactId>
       <version>${core-version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava-version}</version>
-    </dependency>
-    <dependency>
+   <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>${commons-cli-version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,7 @@
       <artifactId>guava</artifactId>
       <version>${guava-version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-core</artifactId>
-      <version>4.3.7.Final</version>
-	</dependency>
-    <dependency>
+   <dependency>
       <groupId>javax</groupId>
       <artifactId>javaee-api</artifactId>
       <version>${javaee-api-version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,10 @@
     <jackson-version>2.4.3</jackson-version>
     <javaee-api-version>6.0</javaee-api-version>
     <junit-version>4.11</junit-version>
+    <gson-version>2.3.1</gson-version>
   </properties>
   <dependencies>
-     <dependency>
+   <dependency>
        <groupId>org.apache.commons</groupId>
        <artifactId>commons-lang3</artifactId>
        <version>${commons-lang3-version}</version>
@@ -53,19 +54,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson-version}</version>
-    </dependency>
-    <dependency>
-	<groupId>com.fasterxml.jackson.core</groupId>
-	<artifactId>jackson-annotations</artifactId>
-	<version>${jackson-version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson-version}</version>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson-version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/com/boundary/plugin/sdk/Measurement.java
+++ b/src/main/java/com/boundary/plugin/sdk/Measurement.java
@@ -15,7 +15,6 @@
 package com.boundary.plugin.sdk;
 
 import java.util.Date;
-import static com.google.common.base.Preconditions.*;
 
 /**
  * Encapsulates the data required for a single piece of time series data to be communicated to the Plugin manager
@@ -152,5 +151,20 @@ public class Measurement {
 	private void setTimestamp(Date timestamp) {
 		this.timestamp = (Date)timestamp.clone();
 	}
+
+	/**
+   	* Ensures that an object reference passed as a parameter to the calling method is not null.
+   	*
+   	* @param reference an object reference
+   	* @return the non-null reference that was validated
+   	* @throws NullPointerException if {@code reference} is null
+   	*/
+	public static <T> T checkNotNull(T reference) {
+		if (reference == null) {
+		  throw new NullPointerException();
+		}
+		return reference;
+	}
+
 }
 

--- a/src/main/java/com/boundary/plugin/sdk/MetricDefinition.java
+++ b/src/main/java/com/boundary/plugin/sdk/MetricDefinition.java
@@ -15,8 +15,6 @@ package com.boundary.plugin.sdk;
 
 import java.io.Serializable;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 /**
  * Defines a Boundary Metric
  * 
@@ -26,21 +24,13 @@ public class MetricDefinition implements Serializable {
 	
 	private static final long serialVersionUID = -3245328652144720304L;
 	
-	@JsonProperty
 	protected String name;
-	@JsonProperty
 	protected String displayName;
-	@JsonProperty
 	protected String displayNameShort;
-	@JsonProperty
 	protected String description;
-	@JsonProperty
 	protected long defaultResolutionMS;
-	@JsonProperty
 	protected MetricAggregate defaultAggregate;
-	@JsonProperty
 	protected MetricUnit unit;
-	@JsonProperty
 	protected boolean isDisabled;
 	
 	/**

--- a/src/main/java/com/boundary/plugin/sdk/MoveFile.java
+++ b/src/main/java/com/boundary/plugin/sdk/MoveFile.java
@@ -16,11 +16,13 @@ package com.boundary.plugin.sdk;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.io.Files;
 
 public class MoveFile implements PostExtract{
 	
@@ -40,12 +42,35 @@ public class MoveFile implements PostExtract{
 			}
 			File from = new File(args[0]);
 			File to = new File(args[1]);
-			Files.copy(from,to);
+			copy(from,to);
 			result = 0;
 		} catch (Exception e) {
 			LOG.error("%s%n",e.getMessage());
 		}
 		return result;
+	}
+
+	/**
+   * Copies all the bytes from one file to another.
+   *
+   * @param from the source file
+   * @param to the destination file
+   * @throws IOException if an I/O error occurs
+   */
+	private static void copy(File from, File to) throws IOException {
+		
+		InputStream fromStream = new FileInputStream(from);
+		OutputStream toStream = new FileOutputStream(to);
+    	
+	    byte[] buffer = new byte[1024];
+		
+	    int length;
+	    while ((length = fromStream.read(buffer)) > 0){
+	    	toStream.write(buffer, 0, length);
+	    }
+	 
+	    fromStream.close();
+	    toStream.close();
 	}
 	
 	public static void main(String [] args) {

--- a/src/main/java/com/boundary/plugin/sdk/examples/SimplePlugin.java
+++ b/src/main/java/com/boundary/plugin/sdk/examples/SimplePlugin.java
@@ -15,6 +15,7 @@
 package com.boundary.plugin.sdk.examples;
 
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 
@@ -23,9 +24,8 @@ import com.boundary.plugin.sdk.MeasurementSinkStandardOut;
 import com.boundary.plugin.sdk.Plugin;
 import com.boundary.plugin.sdk.CollectorDispatcher;
 import com.boundary.plugin.sdk.PluginRunner;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
 
 public class SimplePlugin implements Plugin<SimplePluginConfiguration> {
 
@@ -42,14 +42,11 @@ public class SimplePlugin implements Plugin<SimplePluginConfiguration> {
 	
 	@Override
 	public void loadConfiguration() {
-		ObjectMapper mapper = new ObjectMapper();
+		Gson gson = new Gson();
 		try {
-			SimplePluginConfiguration configuration = mapper.readValue(new File("param.json"), SimplePluginConfiguration.class);
+			SimplePluginConfiguration configuration = gson.fromJson(new FileReader("param.json"), SimplePluginConfiguration.class);
 			setConfiguration(configuration);
 		} catch (JsonParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (JsonMappingException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} catch (IOException e) {

--- a/src/main/java/com/boundary/plugin/sdk/jmx/JMXPlugin.java
+++ b/src/main/java/com/boundary/plugin/sdk/jmx/JMXPlugin.java
@@ -14,6 +14,8 @@
 package com.boundary.plugin.sdk.jmx;
 
 import java.io.File;
+import java.io.FileReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 
@@ -24,9 +26,8 @@ import com.boundary.plugin.sdk.CollectorDispatcher;
 import com.boundary.plugin.sdk.MeasurementSink;
 import com.boundary.plugin.sdk.Plugin;
 import com.boundary.plugin.sdk.jmx.extractor.AttributeValueExtractor;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
 
 public class JMXPlugin implements Plugin<JMXPluginConfiguration> {
 	
@@ -53,26 +54,17 @@ public class JMXPlugin implements Plugin<JMXPluginConfiguration> {
 	}
 
 	public void loadConfiguration() {
-		ObjectMapper mapper = new ObjectMapper();
 		try {
-			JMXPluginConfiguration configuration = mapper.readValue(new File(PLUGIN_PARAM_PATH), JMXPluginConfiguration.class);
+			JMXPluginConfiguration configuration = JMXPluginConfiguration.getConfiguration(new FileReader(PLUGIN_PARAM_PATH));
 			setConfiguration(configuration);
-		} catch (JsonParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (JsonMappingException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
+		} catch (FileNotFoundException e) {
 			e.printStackTrace();
 		}
+
 		try {
-			mbeanMap = mapper.readValue(new File(MBEAN_MAP_PATH), MBeanMap.class);
+			Gson gson = new Gson();
+			mbeanMap = gson.fromJson(new FileReader(MBEAN_MAP_PATH), MBeanMap.class);
 		} catch (JsonParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (JsonMappingException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} catch (IOException e) {

--- a/src/main/java/com/boundary/plugin/sdk/jmx/JMXPluginConfiguration.java
+++ b/src/main/java/com/boundary/plugin/sdk/jmx/JMXPluginConfiguration.java
@@ -15,13 +15,17 @@
 package com.boundary.plugin.sdk.jmx;
 
 import java.io.File;
+import java.io.FileReader;
+import java.io.FileNotFoundException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
 
 import com.boundary.plugin.sdk.PluginConfiguration;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
 
 public class JMXPluginConfiguration implements PluginConfiguration {
 
@@ -47,19 +51,27 @@ public class JMXPluginConfiguration implements PluginConfiguration {
 	public void setPollInterval(int pollInterval) {
 		this.pollInterval = pollInterval;
 	}
-	
+
+	public static JMXPluginConfiguration getConfiguration(final String jsonString) {
+		return getConfiguration(new StringReader(jsonString));
+	}
+
 	public static JMXPluginConfiguration getConfiguration() {
-		ObjectMapper mapper = new ObjectMapper();
 		JMXPluginConfiguration configuration = null;
 		try {
-			configuration = mapper.readValue(new File(PLUGIN_PARAMETER_FILENAME), JMXPluginConfiguration.class);
+			configuration = getConfiguration(new BufferedReader(new FileReader(PLUGIN_PARAMETER_FILENAME)));	
+		} catch (FileNotFoundException e) {
+			e.printStackTrace();
+		}
+		return configuration;
+	}
+	
+	public static JMXPluginConfiguration getConfiguration(Reader reader) {
+		Gson gson = new Gson();
+		JMXPluginConfiguration configuration = null;
+		try {
+			configuration = gson.fromJson(reader, JMXPluginConfiguration.class);
 		} catch (JsonParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (JsonMappingException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}

--- a/src/main/java/com/boundary/plugin/sdk/jmx/MBeanAttribute.java
+++ b/src/main/java/com/boundary/plugin/sdk/jmx/MBeanAttribute.java
@@ -14,10 +14,6 @@
 
 package com.boundary.plugin.sdk.jmx;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
-@JsonInclude(Include.NON_NULL)
 public class MBeanAttribute {
 	
 	public enum MetricType {standard};

--- a/src/main/java/com/boundary/plugin/sdk/jmx/MBeanEntry.java
+++ b/src/main/java/com/boundary/plugin/sdk/jmx/MBeanEntry.java
@@ -16,10 +16,6 @@ package com.boundary.plugin.sdk.jmx;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import static com.fasterxml.jackson.annotation.JsonInclude.*;
-
-@JsonInclude(Include.NON_NULL)
 public class MBeanEntry {
 	
 	private String mbean;

--- a/src/main/java/com/boundary/plugin/sdk/jmx/MBeansTransformer.java
+++ b/src/main/java/com/boundary/plugin/sdk/jmx/MBeansTransformer.java
@@ -26,9 +26,7 @@ import javax.management.MBeanInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
-import com.fasterxml.jackson.core.JsonGenerationException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
 
 public class MBeansTransformer<E> {
 	
@@ -93,16 +91,8 @@ public class MBeansTransformer<E> {
 	
 	public void convertToJson() {
 
-		ObjectMapper mapper = new ObjectMapper();
-		try {
-			mapper.writeValue(System.out,this.export());
-		} catch (JsonGenerationException e) {
-			e.printStackTrace();
-		} catch (JsonMappingException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+		Gson gson = new Gson();
+		System.out.print(gson.toJson(this.export()));
 	}
 	
 	public E export() {

--- a/src/main/java/com/boundary/sdk/plugin/Metrics.java
+++ b/src/main/java/com/boundary/sdk/plugin/Metrics.java
@@ -15,11 +15,8 @@ package com.boundary.sdk.plugin;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class Metrics {
 	
-	@JsonProperty
 	List<String> metrics;
 	
 	public Metrics() {

--- a/src/test/java/com/boundary/plugin/sdk/jmx/JMXPluginConfigurationTest.java
+++ b/src/test/java/com/boundary/plugin/sdk/jmx/JMXPluginConfigurationTest.java
@@ -1,0 +1,47 @@
+// Copyright 2014-2015 BMC Software, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.boundary.plugin.sdk.jmx;
+
+import com.boundary.plugin.sdk.jmx.JMXPluginConfiguration;
+import com.boundary.plugin.sdk.jmx.JMXPluginConfigurationItem;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class JMXPluginConfigurationTest {
+
+    @Test
+    public void testDeserialization () {
+        final String jsonString = "{ pollInterval: 2000, items: [ { name: 'myName', host: 'localhost', port: 1234, user: 'myUser', password: 'myPassword', pollInterval: 1000, source: 'mySource' } ]  }";
+
+        JMXPluginConfiguration config = JMXPluginConfiguration.getConfiguration(jsonString);
+        assertNotNull(config);
+        assertEquals(2000, config.getPollInterval());
+        assertEquals(1, config.getItems().size());
+        assertEquals("myName", config.getItems().get(0).getName());
+        assertEquals("localhost", config.getItems().get(0).getHost());
+        assertEquals(1234, config.getItems().get(0).getPort());
+        assertEquals("myUser", config.getItems().get(0).getUser());
+        assertEquals("myPassword", config.getItems().get(0).getPassword());
+        assertEquals("1000", config.getItems().get(0).getPollInterval());
+        assertEquals("mySource", config.getItems().get(0).getSource());
+    }
+
+}

--- a/src/test/java/com/boundary/plugin/sdk/jmx/MBeansTransformerTest.java
+++ b/src/test/java/com/boundary/plugin/sdk/jmx/MBeansTransformerTest.java
@@ -25,9 +25,8 @@ import org.junit.Test;
 
 import com.boundary.plugin.sdk.MetricDefinition;
 import com.boundary.plugin.sdk.MetricDefinitionList;
-import com.fasterxml.jackson.core.JsonGenerationException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.google.gson.Gson;
 
 public class MBeansTransformerTest {
 	
@@ -84,17 +83,8 @@ public class MBeansTransformerTest {
 		transformer.transform();
 		MetricDefinitionList list = transform.getExport();
 
-		ObjectMapper mapper = new ObjectMapper();
-		try {
-			mapper.writeValue(System.out,list);
-		} catch (JsonGenerationException e) {
-			e.printStackTrace();
-		} catch (JsonMappingException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-
+		Gson mapper = new Gson();
+		mapper.toJson(list, System.out);
 	}
 	
 	@Test
@@ -108,20 +98,15 @@ public class MBeansTransformerTest {
 			transformer.transform();
 
 			MBeanMap map = transformer.export();
-
 			for (MBeanEntry entry : map.getMap()) {
 				System.out.println(entry);
 			}
 
-			ObjectMapper mapper = new ObjectMapper();
-			mapper.writeValue(System.out, map);
-			
-		} catch (JsonGenerationException e) {
-			e.printStackTrace();
-		} catch (JsonMappingException e) {
-			e.printStackTrace();
+			Gson gson = new Gson();
+			gson.toJson(map, System.out);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
+		
 	}
 }


### PR DESCRIPTION
* Removed unused dependencies to reduce output package size.
* Replaced Guava dependency with custom code to reduce output package size.
* Replaced Jackson libraries with GSon to reduce output package size.
* Changed pom.xml to generate a package with all dependencies bundled for using in Plugins.